### PR TITLE
Update main.go to properly generate https:// protocol in APPETIZE_APP_URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	logDebugPretty(&response)
 
-	appURL := path.Join("https://appetize.io/app", response.PublicKey)
+	appURL := "https://" + path.Join("appetize.io/app", response.PublicKey)
 	log.Printf("You can check your app at: %s", appURL)
 	fmt.Println()
 


### PR DESCRIPTION
You can see this playground here to demonstrate the issue: https://play.golang.org/p/VPaiToD_XO along with: https://stackoverflow.com/questions/34668012/combine-url-paths-with-path-join

Here is a screenshot on bitrise with the error:

<img width="597" alt="broken_slash" src="https://user-images.githubusercontent.com/841497/42656436-e79d4d56-85e4-11e8-8815-a259293aebaa.png">

This stops us from using this url in other build steps (like sending a slack message with the appetize link as a button)

The code change follows the pattern in client.go as well: https://github.com/bitrise-steplib/steps-appetize-io-deploy/blob/master/appetize/client.go#L175