### PR TITLE
Fix the `APPETIZE_APP_URL` output URL scheme issue:

### DIFF
--- a/appetize/client_test.go
+++ b/appetize/client_test.go
@@ -1,0 +1,35 @@
+package appetize
+
+import "testing"
+
+func Test_baseURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     string
+		appPath   string
+		publicKey string
+		want      string
+	}{
+		{
+			name:      "test_1",
+			token:     "token_abcdefg",
+			appPath:   "./apps/XcodeArchiveTest.app.zip",
+			publicKey: "",
+			want:      "https://token_abcdefg@api.appetize.io/v1/apps",
+		},
+		{
+			name:      "test_2",
+			token:     "token_abcdefg",
+			appPath:   "./apps/XcodeArchiveTest.app.zip",
+			publicKey: "pubkey",
+			want:      "https://token_abcdefg@api.appetize.io/v1/apps/pubkey",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := baseURL(tt.token, tt.appPath, tt.publicKey); got != tt.want {
+				t.Errorf("baseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 
@@ -76,7 +77,8 @@ func main() {
 
 	logDebugPretty(&response)
 
-	appURL := path.Join("https://appetize.io/app", response.PublicKey)
+	appURL := generateAppURL(response.PublicKey)
+
 	log.Printf("You can check your app at: %s", appURL)
 	fmt.Println()
 
@@ -94,6 +96,15 @@ func main() {
 
 // -------------------------------------
 // -- Private methods
+
+func generateAppURL(publicKey string) string {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "appetize.io",
+		Path:   path.Join("app", publicKey),
+	}
+	return u.String()
+}
 
 func failf(format string, v ...interface{}) {
 	log.Errorf(format, v...)

--- a/main_test.go
+++ b/main_test.go
@@ -11,18 +11,18 @@ func Test_generateAppURL(t *testing.T) {
 	}{
 		{
 			name:      "test_1",
-			publicKey: "u2c556dxrxjfjzyh0xgpvb1tvr",
-			want:      "https://appetize.io/app/u2c556dxrxjfjzyh0xgpvb1tvr",
+			publicKey: "u2c556dxrxjfjzy",
+			want:      "https://appetize.io/app/u2c556dxrxjfjzy",
 		},
 		{
 			name:      "test_2",
-			publicKey: "u2c556dxrxjfjzyh0xgpvb1tvr",
-			want:      "https://appetize.io/app/u2c556dxrxjfjzyh0xgpvb1tvr",
+			publicKey: "h0xgpvb1tvr",
+			want:      "https://appetize.io/app/h0xgpvb1tvr",
 		},
 		{
 			name:      "test_3",
-			publicKey: "u2c556dxrxjfjzyh0xgpvb1tvr",
-			want:      "https://appetize.io/app/u2c556dxrxjfjzyh0xgpvb1tvr",
+			publicKey: "lkwo92okosss",
+			want:      "https://appetize.io/app/lkwo92okosss",
 		},
 	}
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func Test_generateAppURL(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		publicKey string
+		want      string
+	}{
+		{
+			name:      "test_1",
+			publicKey: "u2c556dxrxjfjzyh0xgpvb1tvr",
+			want:      "https://appetize.io/app/u2c556dxrxjfjzyh0xgpvb1tvr",
+		},
+		{
+			name:      "test_2",
+			publicKey: "u2c556dxrxjfjzyh0xgpvb1tvr",
+			want:      "https://appetize.io/app/u2c556dxrxjfjzyh0xgpvb1tvr",
+		},
+		{
+			name:      "test_3",
+			publicKey: "u2c556dxrxjfjzyh0xgpvb1tvr",
+			want:      "https://appetize.io/app/u2c556dxrxjfjzyh0xgpvb1tvr",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateAppURL(tt.publicKey); got != tt.want {
+				t.Errorf("generateAppURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The path.Join() calls the `clean` method which removes every `/` duplicates. That's why the URL scheme is wrong (https:// => https:/)

Unit test added